### PR TITLE
[add]: added path for LogGOPSim from atlahs_entry

### DIFF
--- a/atlahs_entry.py
+++ b/atlahs_entry.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+import os
 import subprocess
 
 def main():
@@ -22,10 +23,10 @@ def main():
         required=True,
         help="File to save the output information"
     )
-    
+
     args = parser.parse_args()
     backend = args.backend.lower()
-    
+
     if backend == "ns-3":
         # Initialize and run NS-3 simulator
         print("Using NS-3 simulator")
@@ -35,8 +36,20 @@ def main():
         cmd = f"./sim/htsim_test/sim/datacenter/htsim_eqds -topo sim/htsim_test/sim/datacenter/topologies/leaf_spine_tiny.topo -tm sim/htsim_test/sim/datacenter/connection_matrices/perm_32n_32c_2MB.cm > {args.output_file}"
         subprocess.run(cmd, shell=True)
     elif backend == "lgs":
-        # Initialize and run LGS simulator
+        # If input is .goal, convert to .bin
+        if args.goal_file.endswith(".goal"):
+            print("Creating LogGOPSim .bin file from .goal file")
+            base, _ = os.path.splitext(args.goal_file)  # removes .goal
+            bin_file = base + ".bin"  # replace extension
+            cmd = f"./sim/LogGOPSim/txt2bin -i {args.goal_file} -o {bin_file}"
+            subprocess.run(cmd, shell=True)
+            args.goal_file = bin_file
+        if not args.goal_file.endswith(".bin"):
+            print("Error: LGS backend requires a .bin GOAL file")
+            sys.exit(1)
         print("Using LGS simulator")
+        cmd = f"./sim/LogGOPSim/LogGOPSim -f {args.goal_file} | tee {args.output_file}"
+        subprocess.run(cmd, shell=True)
     else:
         print(f"Error: Unknown simulator backend '{args.backend}'")
         sys.exit(1)


### PR DESCRIPTION
This PR activates the previously empty LGS backend in the entrypoint.

-  If the user provides a .goal file, it is automatically converted to a .bin file with the same name and path.
-  .bin is then passed to the LogGOPSim executable.
-  Output is written to the selected args.output_file.