### PR TITLE
LogGOPSim: include <cstring> for strcmp on newer GCC

### DIFF
--- a/sim/LogGOPSim/Network.hpp
+++ b/sim/LogGOPSim/Network.hpp
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 #include <fstream>
 #include <regex>
+#include <cstring>
 
 #define noorder 1
 #define debug 0


### PR DESCRIPTION
LogGOPSim: include <cstring> for strcmp on newer GCC for building from source